### PR TITLE
Adds the ability to ban and mute users

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,7 +12,6 @@ ENCRYPTION_KEY=your_base64_32byte_key
 # BlueSky / Atproto configuration
 BSKY_BASE_API_URL=https://api.bsky.app
 
-
 # Client URL to which users are redirected after authentication
 CLIENT_URL=https://your-frontend-url.com
 
@@ -27,3 +26,9 @@ RSKY_FEEDGEN=
 
 # RSKY API Key
 RSKY_API_KEY=
+
+# The Green List URI
+MUTE_LIST_URI="at://did:plc:d2mkddsbmnrgr3domzg5qexf/app.bsky.graph.list/3kaaqcnnxi72w"
+
+# Mute List Admin DID, default blackskyweb.xyz
+MUTE_LIST_ADMIN_DID="did:plc:d2mkddsbmnrgr3domzg5qexf"

--- a/.env.sample
+++ b/.env.sample
@@ -32,3 +32,6 @@ MUTE_LIST_URI="at://did:plc:d2mkddsbmnrgr3domzg5qexf/app.bsky.graph.list/3kaaqcn
 
 # Mute List Admin DID, default blackskyweb.xyz
 MUTE_LIST_ADMIN_DID="did:plc:d2mkddsbmnrgr3domzg5qexf"
+
+# How often to run the reconciliation process, defaults 5 mins
+RECONCILIATION_INTERVAL_MS=300000

--- a/migrations/20251003233408_create_muted_users_table.ts
+++ b/migrations/20251003233408_create_muted_users_table.ts
@@ -1,0 +1,33 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.createTable("muted_users", (table) => {
+		table.text("did").primary();
+		table.text("reason");
+		table.timestamp("muted_at").defaultTo(knex.fn.now());
+		table.text("muted_by").notNullable();
+		table.timestamp("last_synced_at");
+		table.text("sync_status").notNullable().defaultTo("synced");
+		table.specificType("tags", "text[]");
+		table.text("record_key");
+		table.index("sync_status");
+		table.index("muted_at");
+	});
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+	const timestamp = new Date().toISOString().replace(/[-T:]|\.\d{3}Z$/g, "");
+
+	// Backup the table before dropping
+	await knex.raw(
+		`CREATE TABLE muted_users_backup_${timestamp} AS TABLE muted_users`,
+	);
+
+	// Drop the table
+	await knex.schema.dropTableIfExists("muted_users");
+
+	console.log(`Backup created with timestamp: ${timestamp}`);
+}
+

--- a/migrations/20251007182253_add_mute_actions_to_moderation_enum.ts
+++ b/migrations/20251007182253_add_mute_actions_to_moderation_enum.ts
@@ -1,0 +1,19 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+	// Add new enum values to the existing moderation_action enum
+	await knex.raw(`
+		ALTER TYPE moderation_action ADD VALUE IF NOT EXISTS 'user_mute';
+		ALTER TYPE moderation_action ADD VALUE IF NOT EXISTS 'user_unmute';
+	`);
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+	// Note: PostgreSQL doesn't support removing enum values directly
+	// This would require recreating the enum type, which is complex with existing data
+	// For rollback, we'll leave the enum values in place since they don't break anything
+	console.log("Note: Cannot remove enum values from moderation_action. Values 'user_mute' and 'user_unmute' will remain.");
+}
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import morgan from 'morgan';
 import cookieParser from 'cookie-parser';
 
 import authRouter from './routes/auth';
+import adminAuthRouter from './routes/admin-auth';
 import clientMetadataRouter from './routes/clientMetadata';
 import feedsRouter from './routes/feeds';
 import devRouter from './routes/dev';
@@ -38,6 +39,7 @@ app.use((req, res, next) => {
 });
 
 app.use('/auth', authRouter);
+app.use('/admin/auth', adminAuthRouter);
 app.use('/oauth', clientMetadataRouter);
 app.use('/api/feeds', feedsRouter);
 app.use('/api', profileRouter);

--- a/src/controllers/admin-auth.controller.ts
+++ b/src/controllers/admin-auth.controller.ts
@@ -1,0 +1,140 @@
+import { Request, Response } from "express";
+import { AdminOAuthClientSingleton } from "../lib/admin-oauth-client";
+
+/**
+ * Initiates the admin OAuth flow for mute list management. Redirects to OAuth for the MUTE_LIST_ADMIN_DID
+ */
+export const adminSignin = async (req: Request, res: Response): Promise<void> => {
+	try {
+		// Verify the designated admin account is set
+		const adminDid = process.env.MUTE_LIST_ADMIN_DID;
+		if (!adminDid) {
+			res.status(500).json({ error: "Admin DID not configured" });
+			return;
+		}
+
+		const adminOAuthClient = await AdminOAuthClientSingleton.getInstance();
+		const url = await adminOAuthClient.authorize(adminDid as string);
+
+		// Redirect directly to the OAuth provider instead of returning JSON
+		res.redirect(url.toString());
+	} catch (err) {
+		console.error("Error initiating admin OAuth:", err);
+		res.status(500).json({ error: "Failed to initiate admin authentication" });
+	}
+};
+
+/**
+ * Handles the admin OAuth callback
+ * Stores admin tokens for mute list operations
+ */
+export const adminCallback = async (req: Request, res: Response): Promise<void> => {
+	try {
+		const adminOAuthClient = await AdminOAuthClientSingleton.getInstance();
+
+		// Process OAuth callback using admin OAuth client
+		const { session } = await adminOAuthClient.callback(
+			new URLSearchParams(req.query as Record<string, string>),
+		);
+
+		if (!session?.sub) {
+			throw new Error("Invalid session: No DID found");
+		}
+
+		// Verify this is the designated admin account
+		const adminDid = process.env.MUTE_LIST_ADMIN_DID;
+		if (!adminDid) {
+			throw new Error("Admin DID not configured");
+		}
+
+		if (session.sub !== adminDid) {
+			throw new Error(`Unauthorized: Expected admin DID ${adminDid}, got ${session.sub}`);
+		}
+
+		// Session is automatically stored by the admin OAuth client's sessionStore
+		console.log(`Admin OAuth authentication successful for ${session.sub}`);
+
+		// Return a simple success page instead of redirecting to frontend
+		res.status(200).send(`
+			<html>
+				<head><title>Admin Authentication Successful</title></head>
+				<body style="font-family: Arial, sans-serif; text-align: center; padding: 50px;">
+					<h1 style="color: green;">✅ Admin Authentication Successful</h1>
+					<p>Admin DID: <code>${session.sub}</code></p>
+					<p>The admin OAuth session has been stored securely.</p>
+					<p>You can now close this window - the mute list reconciliation service will use these credentials.</p>
+				</body>
+			</html>
+		`);
+	} catch (err) {
+		console.error("Admin OAuth callback error:", err);
+		const errorMessage = err instanceof Error ? err.message : "Admin authentication failed";
+
+		// Return a simple error page instead of redirecting to frontend
+		res.status(400).send(`
+			<html>
+				<head><title>Admin Authentication Failed</title></head>
+				<body style="font-family: Arial, sans-serif; text-align: center; padding: 50px;">
+					<h1 style="color: red;">❌ Admin Authentication Failed</h1>
+					<p><strong>Error:</strong> ${errorMessage}</p>
+					<p>Please try again or contact the administrator.</p>
+				</body>
+			</html>
+		`);
+	}
+};
+
+/**
+ * Logs out the admin by clearing their stored tokens
+ */
+export const adminLogout = async (req: Request, res: Response): Promise<void> => {
+	try {
+		const adminDid = process.env.MUTE_LIST_ADMIN_DID;
+		if (!adminDid) {
+			res.status(500).json({ error: "Admin DID not configured" });
+			return;
+		}
+
+		const adminOAuthClient = await AdminOAuthClientSingleton.getInstance();
+		await adminOAuthClient.revoke(adminDid);
+
+		res.json({ success: true, message: "Admin logged out successfully" });
+	} catch (err) {
+		console.error("Error in admin logout:", err);
+		res.status(500).json({ error: "Failed to log out admin" });
+	}
+};
+
+/**
+ * Check admin authentication status
+ */
+export const adminStatus = async (req: Request, res: Response): Promise<void> => {
+	try {
+		const adminDid = process.env.MUTE_LIST_ADMIN_DID;
+		if (!adminDid) {
+			res.status(500).json({ error: "Admin DID not configured" });
+			return;
+		}
+
+		const adminOAuthClient = await AdminOAuthClientSingleton.getInstance();
+
+		// Try to restore the admin session to check if authenticated
+		let isAuthenticated = false;
+		try {
+			const session = await adminOAuthClient.restore(adminDid);
+			isAuthenticated = !!session;
+		} catch (error) {
+			// Session doesn't exist or is invalid
+			isAuthenticated = false;
+		}
+
+		res.json({
+			isAuthenticated,
+			adminDid,
+			loginUrl: isAuthenticated ? null : `${process.env.BASE_URL}/admin/auth/signin?handle=${adminDid}`
+		});
+	} catch (err) {
+		console.error("Error checking admin status:", err);
+		res.status(500).json({ error: "Failed to check admin status" });
+	}
+};

--- a/src/controllers/moderation.controller.ts
+++ b/src/controllers/moderation.controller.ts
@@ -4,11 +4,15 @@ import {
 	fetchModerationServices,
 	reportToBlacksky,
 	reportToOzone,
+	banUserFromTv,
+	unbanUserFromTv,
+	searchBannedUsersFromTv,
 } from "../repos/moderation";
 
-import { customServiceGate } from "../repos/permissions";
-import { Report } from "../lib/types/moderation";
+import { customServiceGate, canPerformAction } from "../repos/permissions";
+import { Report, BannedFromTV } from "../lib/types/moderation";
 import { createModerationLog } from "../repos/logs";
+import { resolveHandleToDid } from "../repos/atproto";
 
 export const getReportOptions = async (
 	req: Request,
@@ -210,6 +214,171 @@ export const reportModerationEvents = async (
 		res.json({ summary });
 	} catch (error: unknown) {
 		console.error("Error reporting moderation events:", error);
+		res.status(500).json({ error: "Internal server error" });
+	}
+};
+
+export const banFromTvBlacksky = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const actingUser = req.user;
+		if (!actingUser) {
+			res.status(401).json({ error: "Unauthorized: No valid session" });
+			return;
+		}
+
+		const { actor, reason, tags } = req.body;
+		if (!actor) {
+			res.status(400).json({ error: "Missing required field: actor" });
+			return;
+		}
+
+		// Check if user has permission for Blacksky feed
+		const blackskyFeedUri = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";
+		const hasPermission = await canPerformAction(actingUser.did, "user_ban", blackskyFeedUri);
+		if (!hasPermission) {
+			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
+			return;
+		}
+
+		// Resolve handle to DID if needed
+		let resolvedDid: string;
+		try {
+			resolvedDid = await resolveHandleToDid(actor);
+		} catch (resolveError) {
+			res.status(400).json({
+				error: `Failed to resolve actor to DID: ${resolveError instanceof Error ? resolveError.message : "Unknown error"}`
+			});
+			return;
+		}
+
+		await banUserFromTv(resolvedDid, reason, tags);
+
+		// Create moderation log
+		await createModerationLog({
+			uri: blackskyFeedUri,
+			performed_by: actingUser.did,
+			action: "user_ban",
+			target_user_did: resolvedDid,
+			metadata: {
+				reason: reason || null,
+				tags: tags || null,
+				feedName: "Blacksky",
+			},
+		});
+
+		res.status(200).json({ success: true });
+	} catch (error) {
+		console.log(error);
+		console.error("Error banning user from TV:", error);
+		res.status(500).json({ error: "Internal server error" });
+	}
+};
+
+export const unbanFromTvBlacksky = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const actingUser = req.user;
+		if (!actingUser) {
+			res.status(401).json({ error: "Unauthorized: No valid session" });
+			return;
+		}
+
+		const { actor } = req.query;
+		if (!actor || typeof actor !== "string") {
+			res.status(400).json({ error: "Missing or invalid query parameter: actor" });
+			return;
+		}
+
+		// Check if user has permission for Blacksky feed
+		const blackskyFeedUri = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";
+		const hasPermission = await canPerformAction(actingUser.did, "user_ban", blackskyFeedUri);
+		if (!hasPermission) {
+			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
+			return;
+		}
+
+		// Resolve handle to DID if needed
+		let resolvedDid: string;
+		try {
+			resolvedDid = await resolveHandleToDid(actor);
+		} catch (resolveError) {
+			res.status(400).json({
+				error: `Failed to resolve actor to DID: ${resolveError instanceof Error ? resolveError.message : "Unknown error"}`
+			});
+			return;
+		}
+
+		await unbanUserFromTv(resolvedDid);
+
+		// Create moderation log
+		await createModerationLog({
+			uri: blackskyFeedUri,
+			performed_by: actingUser.did,
+			action: "user_unban",
+			target_user_did: resolvedDid,
+			metadata: {
+				feedName: "Blacksky",
+			},
+		});
+
+		res.status(200).json({ success: true });
+	} catch (error) {
+		console.error("Error unbanning user from TV:", error);
+		res.status(500).json({ error: "Internal server error" });
+	}
+};
+
+export const searchBanFromTvBlacksky = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const actingUser = req.user;
+		if (!actingUser) {
+			res.status(401).json({ error: "Unauthorized: No valid session" });
+			return;
+		}
+
+		// Check if user has permission for Blacksky feed
+		const blackskyFeedUri = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";
+		const hasPermission = await canPerformAction(actingUser.did, "user_ban", blackskyFeedUri);
+		if (!hasPermission) {
+			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
+			return;
+		}
+
+		const { actor, tag, limit, offset } = req.query;
+		const limitNum = limit ? Number.parseInt(limit as string, 10) : undefined;
+		const offsetNum = offset ? Number.parseInt(offset as string, 10) : undefined;
+
+		// Resolve handle to DID if actor is provided
+		let resolvedDid: string | undefined;
+		if (actor && typeof actor === "string") {
+			try {
+				resolvedDid = await resolveHandleToDid(actor);
+			} catch (resolveError) {
+				res.status(400).json({
+					error: `Failed to resolve actor to DID: ${resolveError instanceof Error ? resolveError.message : "Unknown error"}`
+				});
+				return;
+			}
+		}
+
+		const bannedUsers: BannedFromTV[] = await searchBannedUsersFromTv(
+			resolvedDid,
+			tag as string | undefined,
+			limitNum,
+			offsetNum,
+		);
+
+		res.status(200).json({ bannedUsers });
+	} catch (error) {
+		console.error("Error searching banned users from TV:", error);
 		res.status(500).json({ error: "Internal server error" });
 	}
 };

--- a/src/controllers/moderation.controller.ts
+++ b/src/controllers/moderation.controller.ts
@@ -13,6 +13,7 @@ import { customServiceGate, canPerformAction } from "../repos/permissions";
 import { Report, BannedFromTV } from "../lib/types/moderation";
 import { createModerationLog } from "../repos/logs";
 import { resolveHandleToDid } from "../repos/atproto";
+import { BLACKSKY_FEED_URI } from "../lib/constants/feeds";
 
 export const getReportOptions = async (
 	req: Request,
@@ -236,8 +237,7 @@ export const banFromTvBlacksky = async (
 		}
 
 		// Check if user has permission for Blacksky feed
-		const blackskyFeedUri = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";
-		const hasPermission = await canPerformAction(actingUser.did, "user_ban", blackskyFeedUri);
+		const hasPermission = await canPerformAction(actingUser.did, "user_ban", BLACKSKY_FEED_URI);
 		if (!hasPermission) {
 			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
 			return;
@@ -258,7 +258,7 @@ export const banFromTvBlacksky = async (
 
 		// Create moderation log
 		await createModerationLog({
-			uri: blackskyFeedUri,
+			uri: BLACKSKY_FEED_URI,
 			performed_by: actingUser.did,
 			action: "user_ban",
 			target_user_did: resolvedDid,
@@ -295,8 +295,7 @@ export const unbanFromTvBlacksky = async (
 		}
 
 		// Check if user has permission for Blacksky feed
-		const blackskyFeedUri = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";
-		const hasPermission = await canPerformAction(actingUser.did, "user_ban", blackskyFeedUri);
+		const hasPermission = await canPerformAction(actingUser.did, "user_ban", BLACKSKY_FEED_URI);
 		if (!hasPermission) {
 			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
 			return;
@@ -317,7 +316,7 @@ export const unbanFromTvBlacksky = async (
 
 		// Create moderation log
 		await createModerationLog({
-			uri: blackskyFeedUri,
+			uri: BLACKSKY_FEED_URI,
 			performed_by: actingUser.did,
 			action: "user_unban",
 			target_user_did: resolvedDid,
@@ -345,8 +344,7 @@ export const searchBanFromTvBlacksky = async (
 		}
 
 		// Check if user has permission for Blacksky feed
-		const blackskyFeedUri = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";
-		const hasPermission = await canPerformAction(actingUser.did, "user_ban", blackskyFeedUri);
+		const hasPermission = await canPerformAction(actingUser.did, "user_ban", BLACKSKY_FEED_URI);
 		if (!hasPermission) {
 			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
 			return;

--- a/src/controllers/mute.controller.ts
+++ b/src/controllers/mute.controller.ts
@@ -9,9 +9,7 @@ import { canPerformAction } from "../repos/permissions";
 import { resolveHandleToDid } from "../repos/atproto";
 import { createModerationLog } from "../repos/logs";
 import { MuteFilters } from "../lib/types/moderation";
-
-// Hardcoded Blacksky feed URI for permission checks
-const BLACKSKY_FEED_URI = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";
+import { BLACKSKY_FEED_URI } from "../lib/constants/feeds";
 
 /**
  * Mutes a user by adding them to the mute list

--- a/src/controllers/mute.controller.ts
+++ b/src/controllers/mute.controller.ts
@@ -1,0 +1,296 @@
+import { Request, Response } from "express";
+import {
+	muteUser,
+	unmuteUser,
+	checkMuted,
+	getMutedUsers,
+} from "../repos/mute";
+import { canPerformAction } from "../repos/permissions";
+import { resolveHandleToDid } from "../repos/atproto";
+import { createModerationLog } from "../repos/logs";
+import { MuteFilters } from "../lib/types/moderation";
+
+// Hardcoded Blacksky feed URI for permission checks
+const BLACKSKY_FEED_URI = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";
+
+/**
+ * Mutes a user by adding them to the mute list
+ * Requires mod/admin permissions for Blacksky feed
+ */
+export const muteUserHandler = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const actingUser = req.user;
+		if (!actingUser) {
+			res.status(401).json({ error: "Unauthorized: No valid session" });
+			return;
+		}
+
+		const { actor, reason, tags } = req.body;
+		if (!actor) {
+			res.status(400).json({ error: "Missing required field: actor" });
+			return;
+		}
+
+		// Check if user has permission for Blacksky feed
+		const hasPermission = await canPerformAction(actingUser.did, "user_mute", BLACKSKY_FEED_URI);
+		if (!hasPermission) {
+			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
+			return;
+		}
+
+		// Resolve handle to DID if needed
+		let resolvedDid: string;
+		try {
+			resolvedDid = await resolveHandleToDid(actor);
+		} catch (resolveError) {
+			res.status(400).json({
+				error: `Failed to resolve actor to DID: ${resolveError instanceof Error ? resolveError.message : "Unknown error"}`
+			});
+			return;
+		}
+
+		// Check if user is already muted
+		const isAlreadyMuted = await checkMuted(resolvedDid);
+		if (isAlreadyMuted) {
+			res.status(409).json({ error: "User is already muted" });
+			return;
+		}
+
+		// Mute the user
+		const result = await muteUser(resolvedDid, reason, actingUser.did, tags);
+
+		if (!result.success) {
+			res.status(500).json({ error: result.error || "Failed to mute user" });
+			return;
+		}
+
+		// Create moderation log
+		await createModerationLog({
+			uri: process.env.MUTE_LIST_URI!,
+			performed_by: actingUser.did,
+			action: "user_mute",
+			target_user_did: resolvedDid,
+			metadata: {
+				reason: reason || null,
+				tags: tags || null,
+				feedName: "The Green List",
+			},
+		});
+
+		res.status(200).json({
+			success: true,
+			message: "User muted successfully",
+			did: resolvedDid
+		});
+	} catch (error) {
+		console.error("Error muting user:", error);
+		res.status(500).json({ error: "Internal server error" });
+	}
+};
+
+/**
+ * Unmutes a user by removing them from the mute list
+ * Requires mod/admin permissions for Blacksky feed
+ */
+export const unmuteUserHandler = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const actingUser = req.user;
+		if (!actingUser) {
+			res.status(401).json({ error: "Unauthorized: No valid session" });
+			return;
+		}
+
+		const { actor } = req.query;
+		if (!actor || typeof actor !== "string") {
+			res.status(400).json({ error: "Missing or invalid query parameter: actor" });
+			return;
+		}
+
+		// Check if user has permission for Blacksky feed
+		const hasPermission = await canPerformAction(actingUser.did, "user_mute", BLACKSKY_FEED_URI);
+		if (!hasPermission) {
+			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
+			return;
+		}
+
+		// Resolve handle to DID if needed
+		let resolvedDid: string;
+		try {
+			resolvedDid = await resolveHandleToDid(actor);
+		} catch (resolveError) {
+			res.status(400).json({
+				error: `Failed to resolve actor to DID: ${resolveError instanceof Error ? resolveError.message : "Unknown error"}`
+			});
+			return;
+		}
+
+		// Check if user is actually muted
+		const isMuted = await checkMuted(resolvedDid);
+		if (!isMuted) {
+			res.status(404).json({ error: "User is not currently muted" });
+			return;
+		}
+
+		// Unmute the user
+		const result = await unmuteUser(resolvedDid);
+
+		if (!result.success) {
+			res.status(500).json({ error: result.error || "Failed to unmute user" });
+			return;
+		}
+
+		// Create moderation log
+		await createModerationLog({
+			uri: BLACKSKY_FEED_URI,
+			performed_by: actingUser.did,
+			action: "user_unmute", // New dedicated action type
+			target_user_did: resolvedDid,
+			metadata: {
+				feedName: "Blacksky Mute List",
+			},
+		});
+
+		res.status(200).json({
+			success: true,
+			message: "User unmuted successfully",
+			did: resolvedDid
+		});
+	} catch (error) {
+		console.error("Error unmuting user:", error);
+		res.status(500).json({ error: "Internal server error" });
+	}
+};
+
+/**
+ * Checks if a specific user is muted
+ * Requires mod/admin permissions for Blacksky feed
+ */
+export const checkMutedHandler = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const actingUser = req.user;
+		if (!actingUser) {
+			res.status(401).json({ error: "Unauthorized: No valid session" });
+			return;
+		}
+
+		const { actor } = req.query;
+		if (!actor || typeof actor !== "string") {
+			res.status(400).json({ error: "Missing or invalid query parameter: actor" });
+			return;
+		}
+
+		// Check if user has permission for Blacksky feed
+		const hasPermission = await canPerformAction(actingUser.did, "user_mute", BLACKSKY_FEED_URI);
+		if (!hasPermission) {
+			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
+			return;
+		}
+
+		// Resolve handle to DID if needed
+		let resolvedDid: string;
+		try {
+			resolvedDid = await resolveHandleToDid(actor);
+		} catch (resolveError) {
+			res.status(400).json({
+				error: `Failed to resolve actor to DID: ${resolveError instanceof Error ? resolveError.message : "Unknown error"}`
+			});
+			return;
+		}
+
+		// Check mute status
+		const isMuted = await checkMuted(resolvedDid);
+
+		res.status(200).json({
+			muted: isMuted,
+			did: resolvedDid
+		});
+	} catch (error) {
+		console.error("Error checking mute status:", error);
+		res.status(500).json({ error: "Internal server error" });
+	}
+};
+
+/**
+ * Lists all muted users with optional filtering and pagination
+ * Requires mod/admin permissions for Blacksky feed
+ */
+export const listMutedUsersHandler = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const actingUser = req.user;
+		if (!actingUser) {
+			res.status(401).json({ error: "Unauthorized: No valid session" });
+			return;
+		}
+
+		// Check if user has permission for Blacksky feed
+		const hasPermission = await canPerformAction(actingUser.did, "user_mute", BLACKSKY_FEED_URI);
+		if (!hasPermission) {
+			res.status(403).json({ error: "Insufficient permissions for Blacksky feed" });
+			return;
+		}
+
+		// Parse query parameters
+		const {
+			did,
+			muted_by,
+			sync_status,
+			tag,
+			limit,
+			offset,
+		} = req.query;
+
+		const filters: MuteFilters = {};
+
+		if (did && typeof did === "string") {
+			filters.did = did;
+		}
+		if (muted_by && typeof muted_by === "string") {
+			filters.muted_by = muted_by;
+		}
+		if (sync_status && typeof sync_status === "string") {
+			if (["synced", "pending", "failed"].includes(sync_status)) {
+				filters.sync_status = sync_status as "synced" | "pending" | "failed";
+			}
+		}
+		if (tag && typeof tag === "string") {
+			filters.tag = tag;
+		}
+		if (limit && typeof limit === "string") {
+			const limitNum = Number.parseInt(limit, 10);
+			if (!Number.isNaN(limitNum) && limitNum > 0 && limitNum <= 100) {
+				filters.limit = limitNum;
+			}
+		}
+		if (offset && typeof offset === "string") {
+			const offsetNum = Number.parseInt(offset, 10);
+			if (!Number.isNaN(offsetNum) && offsetNum >= 0) {
+				filters.offset = offsetNum;
+			}
+		}
+
+		// Get muted users
+		const result = await getMutedUsers(filters);
+
+		res.status(200).json({
+			users: result.users,
+			total: result.total,
+			limit: filters.limit || null,
+			offset: filters.offset || 0,
+		});
+	} catch (error) {
+		console.error("Error listing muted users:", error);
+		res.status(500).json({ error: "Internal server error" });
+	}
+};

--- a/src/lib/admin-oauth-client.ts
+++ b/src/lib/admin-oauth-client.ts
@@ -1,0 +1,57 @@
+import { NodeOAuthClient } from '@atproto/oauth-client-node';
+import { Mutex } from "async-mutex";
+import dotenv from "dotenv";
+import { BLUE_SKY_ADMIN_CLIENT_META_DATA } from './constants/oauth-config';
+import { SessionStore, StateStore } from "../repos/storage";
+
+dotenv.config();
+
+const mutex = new Mutex();
+
+/**
+ * Request lock to prevent concurrent access to the session store
+ */
+const requestLock = async <T>(
+	_name: string,
+	fn: () => T | Promise<T> | PromiseLike<T>,
+): Promise<T> => {
+	return await mutex.runExclusive(() => Promise.resolve(fn()));
+};
+
+
+/**
+ * Admin OAuth Client Singleton
+ */
+class AdminOAuthClientSingleton {
+	private static instance: NodeOAuthClient;
+
+	private constructor() {}
+
+	public static async getInstance(): Promise<NodeOAuthClient> {
+		if (!AdminOAuthClientSingleton.instance) {
+			const baseUrl = process.env.BASE_URL;
+			if (!baseUrl) {
+				throw new Error("BASE_URL environment variable is required for admin OAuth client");
+			}
+
+			// Create admin OAuth client with public client configuration
+			AdminOAuthClientSingleton.instance = new NodeOAuthClient({
+				// Admin-specific client metadata
+				clientMetadata: BLUE_SKY_ADMIN_CLIENT_META_DATA,
+
+				// Use existing encrypted database stores
+				stateStore: new StateStore(),
+
+				// Use existing encrypted database session store
+				sessionStore: new SessionStore(),
+
+				// Request lock for concurrent access protection
+				requestLock,
+			});
+		}
+
+		return AdminOAuthClientSingleton.instance;
+	}
+}
+
+export { AdminOAuthClientSingleton };

--- a/src/lib/constants/feeds.ts
+++ b/src/lib/constants/feeds.ts
@@ -1,0 +1,2 @@
+// Hardcoded Blacksky feed URI for permission checks
+export const BLACKSKY_FEED_URI = "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky";

--- a/src/lib/constants/oauth-config.ts
+++ b/src/lib/constants/oauth-config.ts
@@ -25,3 +25,17 @@ export const BLUE_SKY_CLIENT_META_DATA: OAuthClientMetadataInput = {
 	token_endpoint_auth_method: "none",
 	dpop_bound_access_tokens: true,
 };
+
+export const BLUE_SKY_ADMIN_CLIENT_META_DATA: OAuthClientMetadataInput = {
+	// Must be a URL that will expose admin client metadata
+	client_id: `${baseUrl}/admin/auth/client-metadata.json`,
+	client_name: 'Safe Skies Admin',
+	client_uri: baseUrl,
+	redirect_uris: [`${baseUrl}/admin/auth/callback`],
+	grant_types: ['authorization_code', 'refresh_token'],
+	scope: 'atproto transition:generic',
+	response_types: ['code'],
+	application_type: 'web',
+	token_endpoint_auth_method: 'none',
+	dpop_bound_access_tokens: true,
+}

--- a/src/lib/types/moderation.ts
+++ b/src/lib/types/moderation.ts
@@ -3,6 +3,8 @@ export type ModAction =
 	| "post_restore"
 	| "user_ban"
 	| "user_unban"
+	| "user_mute"
+	| "user_unmute"
 	| "mod_promote"
 	| "mod_demote";
 
@@ -44,4 +46,24 @@ export interface BannedFromTV {
 	reason: string | null;
 	createdAt: string | null;
 	tags: string[] | null;
+}
+
+export interface MutedUser {
+	did: string;
+	reason: string | null;
+	muted_at: Date;
+	muted_by: string;
+	last_synced_at: Date | null;
+	sync_status: "synced" | "pending" | "failed";
+	tags: string[] | null;
+	record_key: string | null;
+}
+
+export interface MuteFilters {
+	did?: string;
+	muted_by?: string;
+	sync_status?: "synced" | "pending" | "failed";
+	tag?: string;
+	limit?: number;
+	offset?: number;
 }

--- a/src/lib/types/moderation.ts
+++ b/src/lib/types/moderation.ts
@@ -32,3 +32,16 @@ export interface Report {
 	targetedPost: string;
 	targetedProfile: string;
 }
+
+export interface BanFromTV {
+	did: string;
+	reason?: string;
+	tags?: string[];
+}
+
+export interface BannedFromTV {
+	did: string;
+	reason: string | null;
+	createdAt: string | null;
+	tags: string[] | null;
+}

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -78,9 +78,11 @@ export const canPerformWithRole = (
 	switch (action) {
 		case "mod_promote":
 		case "mod_demote":
+			return role === "admin";
 		case "user_unban":
 		case "user_ban":
-			return role === "admin";
+		case "user_mute":
+		case "user_unmute":
 		case "post_delete":
 		case "post_restore":
 			return role === "mod" || role === "admin";

--- a/src/repos/atproto.ts
+++ b/src/repos/atproto.ts
@@ -1,8 +1,11 @@
-import { AtpAgent } from "@atproto/api";
+import { AtpAgent, Agent } from "@atproto/api";
+import { AdminOAuthClientSingleton } from "../lib/admin-oauth-client";
 
 class AtpAgentSingleton {
 	private static instance: AtpAgent;
+	private static authenticatedInstance: AtpAgent;
 	private constructor() {}
+
 	public static getInstance(): AtpAgent {
 		if (!AtpAgentSingleton.instance) {
 			this.instance = new AtpAgent({
@@ -11,9 +14,47 @@ class AtpAgentSingleton {
 		}
 		return this.instance;
 	}
+
+	public static async getAuthenticatedInstance(): Promise<AtpAgent> {
+		const adminDid = process.env.MUTE_LIST_ADMIN_DID;
+		if (!adminDid) {
+			throw new Error("MUTE_LIST_ADMIN_DID not configured");
+		}
+
+		try {
+			// Get the admin OAuth client
+			const adminOAuthClient = await AdminOAuthClientSingleton.getInstance();
+
+			// Use client.restore() to get the OAuth session
+			// This automatically handles token refresh if needed
+			const oauthSession = await adminOAuthClient.restore(adminDid);
+
+			// Create an Agent directly from the OAuth session
+			// This is the proper way to use OAuth sessions with AT Protocol
+			const agent = new Agent(oauthSession);
+
+			// Cast to AtpAgent for compatibility with existing code
+			// Agent extends AtpAgent, so this is safe
+			return agent as AtpAgent;
+
+		} catch (error) {
+			if (error instanceof Error) {
+				if (error.message.includes('not found') || error.message.includes('No session')) {
+					throw new Error(`Admin OAuth session not found. Please authenticate at ${process.env.BASE_URL}/admin/auth/signin`);
+				}
+				if (error.message.includes('expired') || error.message.includes('refresh')) {
+					throw new Error(`Admin session expired and refresh failed. Please re-authenticate at ${process.env.BASE_URL}/admin/auth/signin`);
+				}
+			}
+
+			console.error("Error getting authenticated admin agent:", error);
+			throw new Error(`Failed to get authenticated admin agent. Please re-authenticate at ${process.env.BASE_URL}/admin/auth/signin`);
+		}
+	}
 }
 
 export const AtprotoAgent = AtpAgentSingleton.getInstance();
+export const getAuthenticatedAtprotoAgent = AtpAgentSingleton.getAuthenticatedInstance;
 
 /**
  * Retrieves the user's actor feeds via the AtprotoAgent

--- a/src/repos/atproto.ts
+++ b/src/repos/atproto.ts
@@ -48,3 +48,30 @@ export const getFeedGenerator = async (feed: string) => {
 		throw new Error("Failed to fetch feed generator data.");
 	}
 };
+
+/**
+ * Resolves a handle or DID to a DID.
+ * If the input is already a DID (starts with "did:"), returns it as-is.
+ * Otherwise, resolves the handle to a DID using the AtprotoAgent.
+ *
+ * @param actor - Either a DID (e.g., "did:plc:abc123") or a handle (e.g., "alice.bsky.social")
+ * @returns The resolved DID
+ */
+export const resolveHandleToDid = async (actor: string): Promise<string> => {
+	// If it's already a DID, return it
+	if (actor.startsWith("did:")) {
+		return actor;
+	}
+
+	// Otherwise, resolve the handle to a DID
+	try {
+		const response = await AtprotoAgent.resolveHandle({ handle: actor });
+		if (!response.success || !response.data.did) {
+			throw new Error("Failed to resolve handle to DID");
+		}
+		return response.data.did;
+	} catch (error) {
+		console.error("Error resolving handle to DID:", error);
+		throw new Error(`Failed to resolve handle "${actor}" to DID`);
+	}
+};

--- a/src/repos/moderation.ts
+++ b/src/repos/moderation.ts
@@ -107,3 +107,89 @@ export async function fetchModerationServices(
 		throw error;
 	}
 }
+
+export async function banUserFromTv(
+	did: string,
+	reason?: string,
+	tags?: string[],
+) {
+	try {
+		const response = await fetch(
+			`${process.env.RSKY_FEEDGEN}/admin/ban`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"X-RSKY-KEY": process.env.RSKY_API_KEY!,
+				},
+				body: JSON.stringify({ did, reason, tags }),
+			},
+		);
+
+		if (!response.ok) {
+			throw new Error(`HTTP error! status: ${response.status}`);
+		}
+
+		return response;
+	} catch (error) {
+		console.error("Error banning user from TV:", error);
+		throw error;
+	}
+}
+
+export async function unbanUserFromTv(did: string) {
+	try {
+		const response = await fetch(
+			`${process.env.RSKY_FEEDGEN}/admin/ban?did=${encodeURIComponent(did)}`,
+			{
+				method: "DELETE",
+				headers: {
+					"X-RSKY-KEY": process.env.RSKY_API_KEY!,
+				},
+			},
+		);
+
+		if (!response.ok) {
+			throw new Error(`HTTP error! status: ${response.status}`);
+		}
+
+		return response;
+	} catch (error) {
+		console.error("Error unbanning user from TV:", error);
+		throw error;
+	}
+}
+
+export async function searchBannedUsersFromTv(
+	did?: string,
+	tag?: string,
+	limit?: number,
+	offset?: number,
+) {
+	try {
+		const params = new URLSearchParams();
+		if (did) params.append("did", did);
+		if (tag) params.append("tag", tag);
+		if (limit) params.append("limit", limit.toString());
+		if (offset) params.append("offset", offset.toString());
+
+		const queryString = params.toString();
+		const url = `${process.env.RSKY_FEEDGEN}/admin/banned${queryString ? `?${queryString}` : ""}`;
+
+		const response = await fetch(url, {
+			method: "GET",
+			headers: {
+				"X-RSKY-KEY": process.env.RSKY_API_KEY!,
+			},
+		});
+
+		if (!response.ok) {
+			throw new Error(`HTTP error! status: ${response.status}`);
+		}
+
+		return await response.json();
+	} catch (error) {
+		console.error("Error searching banned users from TV:", error);
+		throw error;
+	}
+}

--- a/src/repos/mute.ts
+++ b/src/repos/mute.ts
@@ -1,0 +1,399 @@
+import { db } from "../config/db";
+import { MutedUser, MuteFilters } from "../lib/types/moderation";
+import { getAuthenticatedAtprotoAgent } from "./atproto";
+
+/**
+ * Mutes a user by adding them to the remote list and local DB
+ * Uses write-through cache pattern: remote first, then local
+ * Stores record_key for fast unmute operations
+ */
+export async function muteUser(
+	did: string,
+	reason: string | null = null,
+	mutedBy: string,
+	tags: string[] | null = null,
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		// Step 1: Write to remote list first
+		const agent = await getAuthenticatedAtprotoAgent();
+		const response = await agent.com.atproto.repo.createRecord({
+			repo: process.env.MUTE_LIST_ADMIN_DID!,
+			collection: "app.bsky.graph.listitem",
+			record: {
+				subject: did,
+				list: process.env.MUTE_LIST_URI!,
+				createdAt: new Date().toISOString(),
+			},
+		});
+
+		// Extract record key from response URI
+		const recordKey = response.data.uri.split("/").pop()!;
+
+		// Step 2: If remote write succeeds, update local DB with record_key
+		await db("muted_users")
+			.insert({
+				did,
+				reason,
+				muted_by: mutedBy,
+				tags,
+				record_key: recordKey,
+				sync_status: "synced",
+				last_synced_at: new Date(),
+			})
+			.onConflict("did")
+			.merge({
+				reason,
+				muted_by: mutedBy,
+				tags,
+				record_key: recordKey,
+				sync_status: "synced",
+				last_synced_at: new Date(),
+			});
+
+		return { success: true };
+	} catch (error) {
+		// If remote write fails, still add to local DB as 'pending'
+		try {
+			await db("muted_users")
+				.insert({
+					did,
+					reason,
+					muted_by: mutedBy,
+					tags,
+					record_key: null, // No record key if remote write failed
+					sync_status: "pending",
+				})
+				.onConflict("did")
+				.merge({
+					reason,
+					muted_by: mutedBy,
+					tags,
+					record_key: null,
+					sync_status: "pending",
+				});
+
+			return {
+				success: false,
+				error: `Remote write failed, queued for sync: ${error instanceof Error ? error.message : "Unknown error"}`,
+			};
+		} catch (dbError) {
+			console.error("Critical: Both remote and DB writes failed:", error, dbError);
+			return {
+				success: false,
+				error: "Both remote and local writes failed",
+			};
+		}
+	}
+}
+
+/**
+ * Unmutes a user by removing them from the remote list and local DB
+ * Uses stored record_key for O(1) deletion with fallback to search
+ */
+export async function unmuteUser(
+	did: string,
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		const agent = await getAuthenticatedAtprotoAgent();
+
+		// Step 1: Try fast path using stored record_key
+		const localRecord = await db("muted_users").where("did", did).first();
+
+		if (localRecord?.record_key) {
+			try {
+				await agent.com.atproto.repo.deleteRecord({
+					repo: process.env.MUTE_LIST_ADMIN_DID!,
+					collection: "app.bsky.graph.listitem",
+					rkey: localRecord.record_key,
+				});
+
+				// Success - remove from DB
+				await db("muted_users").where("did", did).delete();
+				return { success: true };
+			} catch (error) {
+				// Record key is stale/invalid - fall back to search
+				console.warn(`Stored record_key failed for ${did}, falling back to search:`, error);
+			}
+		}
+
+		// Step 2: Fallback - search through list records
+		const listRecords = await agent.com.atproto.repo.listRecords({
+			repo: process.env.MUTE_LIST_ADMIN_DID!,
+			collection: "app.bsky.graph.listitem",
+		});
+
+		const targetRecord = listRecords.data.records.find(
+			(record: any) =>
+				record.value.subject === did &&
+				record.value.list === process.env.MUTE_LIST_URI!,
+		);
+
+		if (targetRecord) {
+			const rkey = targetRecord.uri.split("/").pop()!;
+
+			// Delete using found record key
+			await agent.com.atproto.repo.deleteRecord({
+				repo: process.env.MUTE_LIST_ADMIN_DID!,
+				collection: "app.bsky.graph.listitem",
+				rkey,
+			});
+
+			// Update our stored record_key for future use (if record still exists)
+			if (localRecord) {
+				await db("muted_users").where("did", did).update({ record_key: rkey });
+			}
+		}
+
+		// Step 3: Remove from local DB regardless
+		await db("muted_users").where("did", did).delete();
+
+		return { success: true };
+	} catch (error) {
+		console.error("Error unmuting user:", error);
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : "Unknown error",
+		};
+	}
+}
+
+/**
+ * Checks if a user is muted by querying the local DB
+ * Includes both 'synced' and 'pending' records for immediate UX
+ */
+export async function checkMuted(did: string): Promise<boolean> {
+	try {
+		const record = await db("muted_users")
+			.where("did", did)
+			.whereIn("sync_status", ["synced", "pending"])
+			.first();
+
+		return !!record;
+	} catch (error) {
+		console.error("Error checking mute status:", error);
+		return false;
+	}
+}
+
+/**
+ * Retrieves muted users with optional filtering and pagination
+ */
+export async function getMutedUsers(filters: MuteFilters = {}): Promise<{
+	users: MutedUser[];
+	total: number;
+}> {
+	try {
+		let query = db("muted_users").select("*");
+
+		// Apply filters
+		if (filters.did) {
+			query = query.where("did", filters.did);
+		}
+		if (filters.muted_by) {
+			query = query.where("muted_by", filters.muted_by);
+		}
+		if (filters.sync_status) {
+			query = query.where("sync_status", filters.sync_status);
+		}
+		if (filters.tag) {
+			query = query.whereRaw("? = ANY(tags)", [filters.tag]);
+		}
+
+		// Get total count
+		const totalQuery = query.clone();
+		const [{ count }] = await totalQuery.count("did as count");
+		const total = Number(count);
+
+		// Apply pagination
+		if (filters.limit) {
+			query = query.limit(filters.limit);
+		}
+		if (filters.offset) {
+			query = query.offset(filters.offset);
+		}
+
+		const users = await query.orderBy("muted_at", "desc");
+
+		return { users, total };
+	} catch (error) {
+		console.error("Error fetching muted users:", error);
+		return { users: [], total: 0 };
+	}
+}
+
+/**
+ * Fetches all members from the remote Bluesky list
+ * Handles pagination to get complete list
+ */
+export async function fetchRemoteListMembers(): Promise<string[]> {
+	try {
+		const agent = await getAuthenticatedAtprotoAgent();
+		const members: string[] = [];
+		let cursor: string | undefined;
+
+		do {
+			const response = await agent.app.bsky.graph.getList({
+				list: process.env.MUTE_LIST_URI!,
+				limit: 100,
+				cursor,
+			});
+
+			// Extract DIDs from list items
+			const dids = response.data.items.map((item) => item.subject.did);
+			members.push(...dids);
+
+			cursor = response.data.cursor;
+		} while (cursor);
+
+		return members;
+	} catch (error) {
+		console.error("Error fetching remote list members:", error);
+		throw error;
+	}
+}
+
+/**
+ * Reconciles the local DB with the remote list state
+ * Handles bidirectional synchronization with record_key updates
+ */
+export async function reconcileMuteList(): Promise<{
+	added: number;
+	removed: number;
+	synced: number;
+	errors: string[];
+}> {
+	const result = {
+		added: 0,
+		removed: 0,
+		synced: 0,
+		errors: [] as string[],
+	};
+
+	try {
+		// Fetch current state from both sources
+		const [remoteMembers, localRecords] = await Promise.all([
+			fetchRemoteListMembers(),
+			db("muted_users").select("did", "sync_status", "record_key"),
+		]);
+
+		const localDids = localRecords.map((r) => r.did);
+
+		// 1. Find external additions (Remote → Local)
+		const toAdd = remoteMembers.filter((did) => !localDids.includes(did));
+
+		if (toAdd.length > 0) {
+			try {
+				// Primary: Bulk insert (fast path)
+				const recordsToInsert = toAdd.map(did => ({
+					did,
+					reason: null,
+					muted_by: "external",
+					tags: null,
+					record_key: null, // Will be populated if needed for unmute
+					sync_status: "synced",
+					last_synced_at: new Date(),
+				}));
+
+				await db("muted_users").insert(recordsToInsert);
+				result.added = toAdd.length;
+				console.log(`Bulk inserted ${toAdd.length} external mutes`);
+
+			} catch (bulkError) {
+				// Fallback: Individual inserts (error isolation)
+				console.warn("Bulk insert failed, falling back to individual inserts:", bulkError);
+
+				for (const did of toAdd) {
+					try {
+						await db("muted_users").insert({
+							did,
+							reason: null,
+							muted_by: "external",
+							tags: null,
+							record_key: null,
+							sync_status: "synced",
+							last_synced_at: new Date(),
+						});
+						result.added++;
+					} catch (error) {
+						result.errors.push(`Failed to add ${did}: ${error}`);
+					}
+				}
+			}
+		}
+
+		// 2. Find external removals (Remote → Local)
+		const toRemove = localDids.filter((did) => !remoteMembers.includes(did));
+
+		for (const did of toRemove) {
+			try {
+				await db("muted_users").where("did", did).delete();
+				result.removed++;
+			} catch (error) {
+				result.errors.push(`Failed to remove ${did}: ${error}`);
+			}
+		}
+
+		// 3. Handle pending/failed records (Local → Remote retry)
+		const pendingRecords = localRecords.filter((r) =>
+			["pending", "failed"].includes(r.sync_status),
+		);
+
+		for (const record of pendingRecords) {
+			if (remoteMembers.includes(record.did)) {
+				// Remote caught up, mark as synced
+				try {
+					await db("muted_users")
+						.where("did", record.did)
+						.update({
+							sync_status: "synced",
+							last_synced_at: new Date(),
+						});
+					result.synced++;
+				} catch (error) {
+					result.errors.push(`Failed to sync ${record.did}: ${error}`);
+				}
+			} else {
+				// Still missing, retry remote write
+				try {
+					const localRecord = await db("muted_users")
+						.where("did", record.did)
+						.first();
+
+					if (localRecord) {
+						const muteResult = await muteUser(
+							record.did,
+							localRecord.reason,
+							localRecord.muted_by,
+							localRecord.tags,
+						);
+
+						if (muteResult.success) {
+							result.synced++;
+						} else {
+							// Mark as failed after retry
+							await db("muted_users")
+								.where("did", record.did)
+								.update({ sync_status: "failed" });
+							result.errors.push(`Retry failed for ${record.did}: ${muteResult.error}`);
+						}
+					}
+				} catch (error) {
+					result.errors.push(`Failed to retry ${record.did}: ${error}`);
+				}
+			}
+		}
+
+		// 4. Update last_synced_at for all synced records
+		await db("muted_users")
+			.where("sync_status", "synced")
+			.update({ last_synced_at: new Date() });
+
+		console.log("Mute list reconciliation complete:", result);
+		return result;
+	} catch (error) {
+		const errorMsg = `Reconciliation failed: ${error instanceof Error ? error.message : "Unknown error"}`;
+		console.error(errorMsg);
+		result.errors.push(errorMsg);
+		return result;
+	}
+}

--- a/src/routes/admin-auth.ts
+++ b/src/routes/admin-auth.ts
@@ -1,0 +1,40 @@
+import { Router, Request, Response } from "express";
+import {
+	adminSignin,
+	adminCallback,
+	adminLogout,
+	adminStatus
+} from "../controllers/admin-auth.controller";
+import { BLUE_SKY_ADMIN_CLIENT_META_DATA } from "../lib/constants/oauth-config";
+
+const router = Router();
+
+// Admin OAuth flow endpoints
+router.get("/signin", adminSignin);
+router.get("/callback", adminCallback);
+router.post("/logout", adminLogout);
+router.get("/status", adminStatus);
+
+/**
+ * Serve admin OAuth client metadata
+ * This endpoint is required by the AT Protocol OAuth specification
+ * The client_id URL must point to this endpoint
+ */
+router.get("/client-metadata.json", async (req: Request, res: Response): Promise<void> => {
+	try {
+		// Set proper headers for JSON metadata
+		res.setHeader('Content-Type', 'application/json');
+		res.setHeader('Cache-Control', 'public, max-age=3600'); // Cache for 1 hour
+
+		res.json(BLUE_SKY_ADMIN_CLIENT_META_DATA);
+	} catch (error) {
+		console.error("Error serving admin OAuth client metadata:", error);
+		res.status(500).json({
+			error: "internal_server_error",
+			error_description: "Failed to load admin OAuth client metadata"
+		});
+	}
+});
+
+
+export default router;

--- a/src/routes/moderation.ts
+++ b/src/routes/moderation.ts
@@ -7,6 +7,12 @@ import {
 	unbanFromTvBlacksky,
 	searchBanFromTvBlacksky,
 } from "../controllers/moderation.controller";
+import {
+	muteUserHandler,
+	unmuteUserHandler,
+	checkMutedHandler,
+	listMutedUsersHandler,
+} from "../controllers/mute.controller";
 import { authenticateJWT } from "../middleware/auth.middleware";
 
 const router = Router();
@@ -18,5 +24,11 @@ router.post("/report", authenticateJWT, reportModerationEvents);
 router.post("/user/ban", authenticateJWT, banFromTvBlacksky);
 router.delete("/user/ban", authenticateJWT, unbanFromTvBlacksky);
 router.get("/user/ban", authenticateJWT, searchBanFromTvBlacksky);
+
+router.post("/user/mute", authenticateJWT, muteUserHandler);
+router.delete("/user/mute", authenticateJWT, unmuteUserHandler);
+router.get("/user/mute/check", authenticateJWT, checkMutedHandler);
+router.get("/user/mute", authenticateJWT, listMutedUsersHandler);
+
 
 export default router;

--- a/src/routes/moderation.ts
+++ b/src/routes/moderation.ts
@@ -3,6 +3,9 @@ import {
 	getModerationServices,
 	getReportOptions,
 	reportModerationEvents,
+	banFromTvBlacksky,
+	unbanFromTvBlacksky,
+	searchBanFromTvBlacksky,
 } from "../controllers/moderation.controller";
 import { authenticateJWT } from "../middleware/auth.middleware";
 
@@ -11,5 +14,9 @@ const router = Router();
 router.get("/report-options", getReportOptions);
 router.get("/services", authenticateJWT, getModerationServices);
 router.post("/report", authenticateJWT, reportModerationEvents);
+
+router.post("/user/ban", authenticateJWT, banFromTvBlacksky);
+router.delete("/user/ban", authenticateJWT, unbanFromTvBlacksky);
+router.get("/user/ban", authenticateJWT, searchBanFromTvBlacksky);
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,13 @@
 import app from "./app";
+import { startReconciliationService } from "./services/reconciliation";
 
 const PORT = process.env.PORT || 5000;
+
 app.listen(PORT, () => {
 	if (process.env.NODE_ENV === "development") {
 		console.log(`Server running on port ${PORT}`);
 	}
+
+	// Start the mute list reconciliation service
+	startReconciliationService();
 });

--- a/src/services/reconciliation.ts
+++ b/src/services/reconciliation.ts
@@ -1,0 +1,102 @@
+import { reconcileMuteList } from "../repos/mute";
+
+let reconciliationInterval: NodeJS.Timeout | null = null;
+let isRunning = false;
+
+/**
+ * Starts the background reconciliation service
+ * Syncs local mute list DB with remote Bluesky list at regular intervals
+ */
+export function startReconciliationService(): void {
+	// Get interval from environment, default to 5 minutes (300000ms)
+	const intervalMs = Number(process.env.RECONCILIATION_INTERVAL_MS) || 300000;
+
+	if (reconciliationInterval) {
+		console.warn("Reconciliation service is already running");
+		return;
+	}
+
+	console.log(`Starting mute list reconciliation service (interval: ${intervalMs}ms)`);
+
+	// Run reconciliation immediately on start
+	runReconciliation();
+
+	// Set up recurring reconciliation
+	reconciliationInterval = setInterval(() => {
+		runReconciliation();
+	}, intervalMs);
+}
+
+/**
+ * Stops the background reconciliation service
+ */
+export function stopReconciliationService(): void {
+	if (reconciliationInterval) {
+		clearInterval(reconciliationInterval);
+		reconciliationInterval = null;
+		console.log("Mute list reconciliation service stopped");
+	}
+}
+
+/**
+ * Manually triggers a reconciliation run
+ * Can be called independently of the scheduled service
+ */
+export async function runReconciliation(): Promise<void> {
+	if (isRunning) {
+		console.log("Reconciliation already in progress, skipping...");
+		return;
+	}
+
+	isRunning = true;
+	const startTime = Date.now();
+
+	try {
+		console.log("Starting mute list reconciliation...");
+
+		const result = await reconcileMuteList();
+
+		const duration = Date.now() - startTime;
+		console.log(`Mute list reconciliation completed in ${duration}ms:`, {
+			added: result.added,
+			removed: result.removed,
+			synced: result.synced,
+			errors: result.errors.length
+		});
+
+		if (result.errors.length > 0) {
+			console.error("Reconciliation errors:", result.errors);
+		}
+	} catch (error) {
+		const duration = Date.now() - startTime;
+
+		// Check if this is an OAuth authentication error
+		if (error instanceof Error && error.message.includes("OAuth session not found")) {
+			console.error(`Mute list reconciliation failed after ${duration}ms - Admin OAuth authentication required:`, error.message);
+			console.error(`Please authenticate admin at: ${process.env.BASE_URL}/admin/auth/signin?handle=${process.env.MUTE_LIST_ADMIN_DID}`);
+		} else if (error instanceof Error && error.message.includes("session expired")) {
+			console.error(`Mute list reconciliation failed after ${duration}ms - Admin session expired:`, error.message);
+		} else {
+			console.error(`Mute list reconciliation failed after ${duration}ms:`, error);
+		}
+	} finally {
+		isRunning = false;
+	}
+}
+
+/**
+ * Returns the current status of the reconciliation service
+ */
+export function getReconciliationStatus(): {
+	running: boolean;
+	intervalMs: number;
+	isCurrentlyReconciling: boolean;
+} {
+	const intervalMs = Number(process.env.RECONCILIATION_INTERVAL_MS) || 300000;
+
+	return {
+		running: reconciliationInterval !== null,
+		intervalMs,
+		isCurrentlyReconciling: isRunning
+	};
+}

--- a/test/integration/logging/logs.routes.test.ts
+++ b/test/integration/logging/logs.routes.test.ts
@@ -1,8 +1,8 @@
 import request from "supertest";
 import app from "../../../src/app";
-import { mockGetLogs, setupLogsMocks } from "../../mocks/logs.mocks";
 import { mockLogEntries } from "../../fixtures/logs.fixtures";
 import * as permissions from "../../../src/repos/permissions";
+import { getLogs }  from "../../../src/repos/logs";
 import jwt from "jsonwebtoken";
 import { LogEntry } from "../../../src/lib/types/logs";
 import {
@@ -11,8 +11,8 @@ import {
 	mockUser,
 } from "../../fixtures/user.fixtures";
 
-// Setup logs mocks
-setupLogsMocks();
+// Mock the logs repository module
+jest.mock("../../../src/repos/logs");
 
 // Mock JWT verify directly - this is the most reliable approach
 jest.mock("jsonwebtoken", () => {
@@ -34,7 +34,7 @@ describe("Logs Routes Integration", () => {
 		(permissions.getUserRoleForFeed as jest.Mock).mockResolvedValue("admin");
 
 		// Reset getLogs mock
-		mockGetLogs.mockResolvedValue(mockLogEntries);
+		(getLogs as jest.Mock).mockResolvedValue(mockLogEntries);
 	});
 
 	afterEach(() => {

--- a/test/integration/moderation/blacksky.routes.test.ts
+++ b/test/integration/moderation/blacksky.routes.test.ts
@@ -1,0 +1,379 @@
+import request from "supertest";
+import app from "../../../src/app";
+import { mockUser, mockTargetUser } from "../../fixtures/user.fixtures";
+import * as permissions from "../../../src/repos/permissions";
+import * as moderation from "../../../src/repos/moderation";
+import * as mute from "../../../src/repos/mute";
+import * as logs from "../../../src/repos/logs";
+import * as atproto from "../../../src/repos/atproto";
+import jwt from "jsonwebtoken";
+
+// Mock JWT verify directly
+jest.mock("jsonwebtoken", () => {
+	const original = jest.requireActual("jsonwebtoken");
+	return {
+		...original,
+		verify: jest.fn(),
+	};
+});
+
+// Mock all dependencies
+jest.mock("../../../src/repos/permissions");
+jest.mock("../../../src/repos/moderation");
+jest.mock("../../../src/repos/mute");
+jest.mock("../../../src/repos/logs");
+jest.mock("../../../src/repos/atproto", () => ({
+	resolveHandleToDid: jest.fn(),
+	AtprotoAgent: {
+		getProfile: jest.fn(),
+	},
+	getActorFeeds: jest.fn(),
+	getFeedGenerator: jest.fn(),
+	getAuthenticatedAtprotoAgent: jest.fn(),
+}));
+
+describe("Blacksky Routes Integration", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Set default successful auth
+		(jwt.verify as jest.Mock).mockReturnValue(mockUser);
+
+		// Set default permission checks to pass
+		(permissions.canPerformAction as jest.Mock).mockResolvedValue(true);
+
+		// Mock DID resolution
+		(atproto.resolveHandleToDid as jest.Mock).mockResolvedValue(mockTargetUser.did);
+
+		// Mock logging
+		(logs.createModerationLog as jest.Mock).mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	afterAll(() => {
+		jest.restoreAllMocks();
+	});
+
+	describe("Authentication", () => {
+		it("should require authentication for all endpoints", async () => {
+			// Make JWT verification fail
+			(jwt.verify as jest.Mock).mockReturnValue(undefined);
+
+			const endpoints = [
+				{ method: "post", path: "/api/moderation/user/ban", body: { actor: "test.handle" } },
+				{ method: "delete", path: "/api/moderation/user/ban?actor=test.handle" },
+				{ method: "get", path: "/api/moderation/user/ban" },
+				{ method: "post", path: "/api/moderation/user/mute", body: { actor: "test.handle" } },
+				{ method: "delete", path: "/api/moderation/user/mute?actor=test.handle" },
+				{ method: "get", path: "/api/moderation/user/mute/check?actor=test.handle" },
+				{ method: "get", path: "/api/moderation/user/mute" },
+			];
+
+			for (const endpoint of endpoints) {
+				let response;
+				if (endpoint.method === "post") {
+					response = await request(app)
+						.post(endpoint.path)
+						.send(endpoint.body || {})
+						.set("Authorization", "Bearer invalid-token");
+				} else if (endpoint.method === "delete") {
+					response = await request(app)
+						.delete(endpoint.path)
+						.set("Authorization", "Bearer invalid-token");
+				} else {
+					response = await request(app)
+						.get(endpoint.path)
+						.set("Authorization", "Bearer invalid-token");
+				}
+
+				expect(response.status).toBe(401);
+				expect(response.body).toHaveProperty("error", "Unauthorized: No valid session");
+			}
+		});
+
+		it("should require permissions for all endpoints", async () => {
+			// Set permissions to fail
+			(permissions.canPerformAction as jest.Mock).mockResolvedValue(false);
+
+			const endpoints = [
+				{ method: "post", path: "/api/moderation/user/ban", body: { actor: "test.handle" } },
+				{ method: "delete", path: "/api/moderation/user/ban?actor=test.handle" },
+				{ method: "get", path: "/api/moderation/user/ban" },
+				{ method: "post", path: "/api/moderation/user/mute", body: { actor: "test.handle" } },
+				{ method: "delete", path: "/api/moderation/user/mute?actor=test.handle" },
+				{ method: "get", path: "/api/moderation/user/mute/check?actor=test.handle" },
+				{ method: "get", path: "/api/moderation/user/mute" },
+			];
+
+			for (const endpoint of endpoints) {
+				let response;
+				if (endpoint.method === "post") {
+					response = await request(app)
+						.post(endpoint.path)
+						.send(endpoint.body || {})
+						.set("Authorization", "Bearer valid-token");
+				} else if (endpoint.method === "delete") {
+					response = await request(app)
+						.delete(endpoint.path)
+						.set("Authorization", "Bearer valid-token");
+				} else {
+					response = await request(app)
+						.get(endpoint.path)
+						.set("Authorization", "Bearer valid-token");
+				}
+
+				expect(response.status).toBe(403);
+				expect(response.body).toHaveProperty("error", "Insufficient permissions for Blacksky feed");
+			}
+		});
+	});
+
+	describe("Ban Routes", () => {
+		describe("POST /api/moderation/user/ban", () => {
+			it("should ban a user successfully", async () => {
+				const mockResponse = new Response(JSON.stringify({ success: true }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+				(moderation.banUserFromTv as jest.Mock).mockResolvedValue(mockResponse);
+
+				const response = await request(app)
+					.post("/api/moderation/user/ban")
+					.send({
+						actor: mockTargetUser.handle,
+						reason: "spam",
+						tags: ["offensive"],
+					})
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({ success: true });
+				expect(moderation.banUserFromTv).toHaveBeenCalledWith(
+					mockTargetUser.did,
+					"spam",
+					["offensive"]
+				);
+				expect(logs.createModerationLog).toHaveBeenCalled();
+			});
+
+			it("should return 400 if actor is missing", async () => {
+				const response = await request(app)
+					.post("/api/moderation/user/ban")
+					.send({})
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(400);
+				expect(response.body).toHaveProperty("error", "Missing required field: actor");
+			});
+		});
+
+		describe("DELETE /api/moderation/user/ban", () => {
+			it("should unban a user successfully", async () => {
+				const mockResponse = new Response(JSON.stringify({ success: true }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+				(moderation.unbanUserFromTv as jest.Mock).mockResolvedValue(mockResponse);
+
+				const response = await request(app)
+					.delete(`/api/moderation/user/ban?actor=${mockTargetUser.handle}`)
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({ success: true });
+				expect(moderation.unbanUserFromTv).toHaveBeenCalledWith(mockTargetUser.did);
+			});
+		});
+
+		describe("GET /api/moderation/user/ban", () => {
+			it("should search banned users successfully", async () => {
+				const mockBannedUsers = [
+					{
+						did: mockTargetUser.did,
+						reason: "spam",
+						createdAt: "2023-01-01T00:00:00Z",
+						tags: ["offensive"],
+					},
+				];
+				(moderation.searchBannedUsersFromTv as jest.Mock).mockResolvedValue(mockBannedUsers);
+
+				const response = await request(app)
+					.get(`/api/moderation/user/ban?actor=${mockTargetUser.handle}&limit=10`)
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({ bannedUsers: mockBannedUsers });
+				expect(moderation.searchBannedUsersFromTv).toHaveBeenCalledWith(
+					mockTargetUser.did,
+					undefined,
+					10,
+					undefined
+				);
+			});
+		});
+	});
+
+	describe("Mute Routes", () => {
+		describe("POST /api/moderation/user/mute", () => {
+			it("should mute a user successfully", async () => {
+				(mute.checkMuted as jest.Mock).mockResolvedValue(false);
+				(mute.muteUser as jest.Mock).mockResolvedValue({ success: true });
+
+				const response = await request(app)
+					.post("/api/moderation/user/mute")
+					.send({
+						actor: mockTargetUser.handle,
+						reason: "spam",
+						tags: ["offensive"],
+					})
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({
+					success: true,
+					message: "User muted successfully",
+					did: mockTargetUser.did,
+				});
+				expect(mute.checkMuted).toHaveBeenCalledWith(mockTargetUser.did);
+				expect(mute.muteUser).toHaveBeenCalledWith(
+					mockTargetUser.did,
+					"spam",
+					mockUser.did,
+					["offensive"]
+				);
+			});
+
+			it("should return 409 if user is already muted", async () => {
+				(mute.checkMuted as jest.Mock).mockResolvedValue(true);
+
+				const response = await request(app)
+					.post("/api/moderation/user/mute")
+					.send({ actor: mockTargetUser.handle })
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(409);
+				expect(response.body).toHaveProperty("error", "User is already muted");
+			});
+		});
+
+		describe("DELETE /api/moderation/user/mute", () => {
+			it("should unmute a user successfully", async () => {
+				(mute.checkMuted as jest.Mock).mockResolvedValue(true);
+				(mute.unmuteUser as jest.Mock).mockResolvedValue({ success: true });
+
+				const response = await request(app)
+					.delete(`/api/moderation/user/mute?actor=${mockTargetUser.handle}`)
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({
+					success: true,
+					message: "User unmuted successfully",
+					did: mockTargetUser.did,
+				});
+				expect(mute.unmuteUser).toHaveBeenCalledWith(mockTargetUser.did);
+			});
+
+			it("should return 404 if user is not muted", async () => {
+				(mute.checkMuted as jest.Mock).mockResolvedValue(false);
+
+				const response = await request(app)
+					.delete(`/api/moderation/user/mute?actor=${mockTargetUser.handle}`)
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(404);
+				expect(response.body).toHaveProperty("error", "User is not currently muted");
+			});
+		});
+
+		describe("GET /api/moderation/user/mute/check", () => {
+			it("should check mute status successfully", async () => {
+				(mute.checkMuted as jest.Mock).mockResolvedValue(true);
+
+				const response = await request(app)
+					.get(`/api/moderation/user/mute/check?actor=${mockTargetUser.handle}`)
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({
+					muted: true,
+					did: mockTargetUser.did,
+				});
+				expect(mute.checkMuted).toHaveBeenCalledWith(mockTargetUser.did);
+			});
+		});
+
+		describe("GET /api/moderation/user/mute", () => {
+			it("should list muted users successfully", async () => {
+				const mockMutedUsers = {
+					users: [
+						{
+							did: mockTargetUser.did,
+							reason: "spam",
+							muted_at: "2023-01-01T00:00:00.000Z",
+							muted_by: mockUser.did,
+							last_synced_at: "2023-01-01T00:00:00.000Z",
+							sync_status: "synced",
+							tags: ["offensive"],
+							record_key: "abc123",
+						},
+					],
+					total: 1,
+				};
+				(mute.getMutedUsers as jest.Mock).mockResolvedValue(mockMutedUsers);
+
+				const response = await request(app)
+					.get("/api/moderation/user/mute?limit=10&offset=0")
+					.set("Authorization", "Bearer valid-token");
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({
+					users: mockMutedUsers.users,
+					total: 1,
+					limit: 10,
+					offset: 0,
+				});
+				expect(mute.getMutedUsers).toHaveBeenCalledWith({
+					limit: 10,
+					offset: 0,
+				});
+			});
+		});
+	});
+
+	describe("Error Handling", () => {
+		it("should handle DID resolution errors", async () => {
+			(atproto.resolveHandleToDid as jest.Mock).mockRejectedValue(
+				new Error("Handle not found")
+			);
+
+			const response = await request(app)
+				.post("/api/moderation/user/ban")
+				.send({ actor: "invalid.handle" })
+				.set("Authorization", "Bearer valid-token");
+
+			expect(response.status).toBe(400);
+			expect(response.body).toHaveProperty(
+				"error",
+				"Failed to resolve actor to DID: Handle not found"
+			);
+		});
+
+		it("should handle repository errors gracefully", async () => {
+			(moderation.banUserFromTv as jest.Mock).mockRejectedValue(
+				new Error("External API error")
+			);
+
+			const response = await request(app)
+				.post("/api/moderation/user/ban")
+				.send({ actor: mockTargetUser.handle })
+				.set("Authorization", "Bearer valid-token");
+
+			expect(response.status).toBe(500);
+			expect(response.body).toHaveProperty("error", "Internal server error");
+		});
+	});
+});

--- a/test/mocks/moderation.mocks.ts
+++ b/test/mocks/moderation.mocks.ts
@@ -1,5 +1,6 @@
 jest.mock("../../src/repos/permissions", () => ({
 	customServiceGate: jest.fn(),
+	canPerformAction: jest.fn(),
 }));
 
 jest.mock("../../src/repos/moderation", () => ({
@@ -14,12 +15,13 @@ jest.mock("../../src/repos/logs", () => ({
 }));
 
 // Import the actual functions so we can cast them as mocks.
-import { customServiceGate } from "../../src/repos/permissions";
+import { customServiceGate, canPerformAction } from "../../src/repos/permissions";
 import { reportToBlacksky, reportToOzone } from "../../src/repos/moderation";
 import { createModerationLog } from "../../src/repos/logs";
 
 // Export the mocks for use in tests.
 export const mockedCustomServiceGate = customServiceGate as jest.Mock;
+export const mockedCanPerformAction = canPerformAction as jest.Mock;
 export const mockedReportToBlacksky = reportToBlacksky as jest.Mock;
 export const mockedReportToOzone = reportToOzone as jest.Mock;
 export const mockedCreateModerationLog = createModerationLog as jest.Mock;

--- a/test/unit/moderation/blacksky.controller.test.ts
+++ b/test/unit/moderation/blacksky.controller.test.ts
@@ -1,0 +1,432 @@
+import { Request, Response } from "express";
+import {
+	createMockRequest,
+	createMockResponse,
+	mockStatus,
+	mockJson,
+} from "../../mocks/express.mock";
+
+// Import ban controllers
+import {
+	banFromTvBlacksky,
+	unbanFromTvBlacksky,
+	searchBanFromTvBlacksky,
+} from "../../../src/controllers/moderation.controller";
+
+// Import mute controllers
+import {
+	muteUserHandler,
+	unmuteUserHandler,
+	checkMutedHandler,
+	listMutedUsersHandler,
+} from "../../../src/controllers/mute.controller";
+
+// Import fixtures
+import {
+	mockUser,
+	mockTargetUser,
+} from "../../fixtures/user.fixtures";
+
+// Mock repository modules
+import * as moderation from "../../../src/repos/moderation";
+import * as mute from "../../../src/repos/mute";
+import * as permissions from "../../../src/repos/permissions";
+import * as logs from "../../../src/repos/logs";
+import * as atproto from "../../../src/repos/atproto";
+
+// Add resolveHandleToDid to the existing atproto mock
+jest.mock("../../../src/repos/atproto", () => ({
+	...jest.requireActual("../../../src/repos/atproto"),
+	resolveHandleToDid: jest.fn(),
+	AtprotoAgent: {
+		getProfile: jest.fn(async (params: { actor: string }) => {
+			return {
+				success: true,
+				data: {
+					did: params.actor,
+					handle: "testHandle",
+					displayName: "Test User",
+				},
+			};
+		}),
+	},
+	getActorFeeds: jest.fn(async () => ({
+		feeds: [
+			{ uri: "feed:1", displayName: "Feed One", creator: { did: "admin1" } },
+		],
+	})),
+	getFeedGenerator: jest.fn(async (feed: string) => {
+		if (feed === "feed:1") {
+			return {
+				displayName: "BlueSky Feed One",
+				description: "Updated Desc 1",
+				did: "did:example:456",
+			};
+		} else if (feed === "feed:2") {
+			return {
+				displayName: "BlueSky Feed Two",
+				description: "Updated Desc 2",
+				did: "did:example:456",
+			};
+		}
+		throw new Error("Feed not found");
+	}),
+}));
+
+describe("Blacksky Controllers", () => {
+	let req: Request;
+	let res: Response;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		res = createMockResponse();
+
+		// Default mocks
+		jest.spyOn(permissions, "canPerformAction").mockResolvedValue(true);
+		jest.spyOn(logs, "createModerationLog").mockResolvedValue(undefined);
+		(atproto.resolveHandleToDid as jest.Mock).mockImplementation((actor: string) =>
+			Promise.resolve(actor) // Return input as-is, simulating DID pass-through
+		);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		jest.restoreAllMocks();
+	});
+
+	describe("Ban Controllers", () => {
+		describe("banFromTvBlacksky", () => {
+			it("should ban a user successfully", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					body: { actor: mockTargetUser.did, reason: "spam", tags: ["offensive"] },
+				});
+
+				const mockResponse = new Response(JSON.stringify({ success: true }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+				jest.spyOn(moderation, "banUserFromTv").mockResolvedValue(mockResponse);
+
+				await banFromTvBlacksky(req, res);
+
+				expect(moderation.banUserFromTv).toHaveBeenCalledWith(
+					mockTargetUser.did,
+					"spam",
+					["offensive"]
+				);
+				expect(logs.createModerationLog).toHaveBeenCalledWith({
+					uri: "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky",
+					performed_by: mockUser.did,
+					action: "user_ban",
+					target_user_did: mockTargetUser.did,
+					metadata: {
+						reason: "spam",
+						tags: ["offensive"],
+						feedName: "Blacksky",
+					},
+				});
+				expect(mockStatus).toHaveBeenCalledWith(200);
+				expect(mockJson).toHaveBeenCalledWith({ success: true });
+			});
+
+			it("should return 401 if no user is authenticated", async () => {
+				req = createMockRequest({
+					user: undefined,
+					body: { actor: mockTargetUser.did },
+				});
+
+				await banFromTvBlacksky(req, res);
+
+				expect(mockStatus).toHaveBeenCalledWith(401);
+				expect(mockJson).toHaveBeenCalledWith({
+					error: "Unauthorized: No valid session",
+				});
+			});
+
+			it("should return 400 if actor is missing", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					body: {},
+				});
+
+				await banFromTvBlacksky(req, res);
+
+				expect(mockStatus).toHaveBeenCalledWith(400);
+				expect(mockJson).toHaveBeenCalledWith({
+					error: "Missing required field: actor",
+				});
+			});
+
+			it("should return 403 if user lacks permissions", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					body: { actor: mockTargetUser.did },
+				});
+
+				jest.spyOn(permissions, "canPerformAction").mockResolvedValue(false);
+
+				await banFromTvBlacksky(req, res);
+
+				expect(mockStatus).toHaveBeenCalledWith(403);
+				expect(mockJson).toHaveBeenCalledWith({
+					error: "Insufficient permissions for Blacksky feed",
+				});
+			});
+
+		});
+
+		describe("unbanFromTvBlacksky", () => {
+			it("should unban a user successfully", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					query: { actor: mockTargetUser.did },
+				});
+
+				const mockResponse = new Response(JSON.stringify({ success: true }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+				jest.spyOn(moderation, "unbanUserFromTv").mockResolvedValue(mockResponse);
+
+				await unbanFromTvBlacksky(req, res);
+
+				expect(moderation.unbanUserFromTv).toHaveBeenCalledWith(mockTargetUser.did);
+				expect(logs.createModerationLog).toHaveBeenCalledWith({
+					uri: "at://did:plc:w4xbfzo7kqfes5zb7r6qv3rw/app.bsky.feed.generator/blacksky",
+					performed_by: mockUser.did,
+					action: "user_unban",
+					target_user_did: mockTargetUser.did,
+					metadata: {
+						feedName: "Blacksky",
+					},
+				});
+				expect(mockStatus).toHaveBeenCalledWith(200);
+				expect(mockJson).toHaveBeenCalledWith({ success: true });
+			});
+
+			it("should return 400 if actor query parameter is missing", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					query: {},
+				});
+
+				await unbanFromTvBlacksky(req, res);
+
+				expect(mockStatus).toHaveBeenCalledWith(400);
+				expect(mockJson).toHaveBeenCalledWith({
+					error: "Missing or invalid query parameter: actor",
+				});
+			});
+		});
+
+		describe("searchBanFromTvBlacksky", () => {
+			it("should search banned users successfully", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					query: { actor: mockTargetUser.did, limit: "10", offset: "0" },
+				});
+
+				const mockBannedUsers = [
+					{
+						did: mockTargetUser.did,
+						reason: "spam",
+						createdAt: "2023-01-01T00:00:00Z",
+						tags: ["offensive"],
+					},
+				];
+				jest.spyOn(moderation, "searchBannedUsersFromTv").mockResolvedValue(mockBannedUsers);
+
+				await searchBanFromTvBlacksky(req, res);
+
+				expect(moderation.searchBannedUsersFromTv).toHaveBeenCalledWith(
+					mockTargetUser.did,
+					undefined,
+					10,
+					0
+				);
+				expect(mockStatus).toHaveBeenCalledWith(200);
+				expect(mockJson).toHaveBeenCalledWith({ bannedUsers: mockBannedUsers });
+			});
+		});
+	});
+
+	describe("Mute Controllers", () => {
+		describe("muteUserHandler", () => {
+			it("should mute a user successfully", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					body: { actor: mockTargetUser.did, reason: "spam", tags: ["offensive"] },
+				});
+
+				jest.spyOn(mute, "checkMuted").mockResolvedValue(false);
+				jest.spyOn(mute, "muteUser").mockResolvedValue({ success: true });
+
+				await muteUserHandler(req, res);
+
+				expect(mute.checkMuted).toHaveBeenCalledWith(mockTargetUser.did);
+				expect(mute.muteUser).toHaveBeenCalledWith(
+					mockTargetUser.did,
+					"spam",
+					mockUser.did,
+					["offensive"]
+				);
+				expect(logs.createModerationLog).toHaveBeenCalledWith({
+					uri: process.env.MUTE_LIST_URI,
+					performed_by: mockUser.did,
+					action: "user_mute",
+					target_user_did: mockTargetUser.did,
+					metadata: {
+						reason: "spam",
+						tags: ["offensive"],
+						feedName: "The Green List",
+					},
+				});
+				expect(mockStatus).toHaveBeenCalledWith(200);
+				expect(mockJson).toHaveBeenCalledWith({
+					success: true,
+					message: "User muted successfully",
+					did: mockTargetUser.did,
+				});
+			});
+
+			it("should return 409 if user is already muted", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					body: { actor: mockTargetUser.did },
+				});
+
+				jest.spyOn(mute, "checkMuted").mockResolvedValue(true);
+
+				await muteUserHandler(req, res);
+
+				expect(mockStatus).toHaveBeenCalledWith(409);
+				expect(mockJson).toHaveBeenCalledWith({
+					error: "User is already muted",
+				});
+			});
+
+			it("should handle mute operation failure", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					body: { actor: mockTargetUser.did },
+				});
+
+				jest.spyOn(mute, "checkMuted").mockResolvedValue(false);
+				jest.spyOn(mute, "muteUser").mockResolvedValue({
+					success: false,
+					error: "Database error",
+				});
+
+				await muteUserHandler(req, res);
+
+				expect(mockStatus).toHaveBeenCalledWith(500);
+				expect(mockJson).toHaveBeenCalledWith({
+					error: "Database error",
+				});
+			});
+		});
+
+		describe("unmuteUserHandler", () => {
+			it("should unmute a user successfully", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					query: { actor: mockTargetUser.did },
+				});
+
+				jest.spyOn(mute, "checkMuted").mockResolvedValue(true);
+				jest.spyOn(mute, "unmuteUser").mockResolvedValue({ success: true });
+
+				await unmuteUserHandler(req, res);
+
+				expect(mute.checkMuted).toHaveBeenCalledWith(mockTargetUser.did);
+				expect(mute.unmuteUser).toHaveBeenCalledWith(mockTargetUser.did);
+				expect(mockStatus).toHaveBeenCalledWith(200);
+				expect(mockJson).toHaveBeenCalledWith({
+					success: true,
+					message: "User unmuted successfully",
+					did: mockTargetUser.did,
+				});
+			});
+
+			it("should return 404 if user is not muted", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					query: { actor: mockTargetUser.did },
+				});
+
+				jest.spyOn(mute, "checkMuted").mockResolvedValue(false);
+
+				await unmuteUserHandler(req, res);
+
+				expect(mockStatus).toHaveBeenCalledWith(404);
+				expect(mockJson).toHaveBeenCalledWith({
+					error: "User is not currently muted",
+				});
+			});
+		});
+
+		describe("checkMutedHandler", () => {
+			it("should check mute status successfully", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					query: { actor: mockTargetUser.did },
+				});
+
+				jest.spyOn(mute, "checkMuted").mockResolvedValue(true);
+
+				await checkMutedHandler(req, res);
+
+				expect(mute.checkMuted).toHaveBeenCalledWith(mockTargetUser.did);
+				expect(mockStatus).toHaveBeenCalledWith(200);
+				expect(mockJson).toHaveBeenCalledWith({
+					muted: true,
+					did: mockTargetUser.did,
+				});
+			});
+		});
+
+		describe("listMutedUsersHandler", () => {
+			it("should list muted users successfully", async () => {
+				req = createMockRequest({
+					user: { did: mockUser.did, handle: mockUser.handle },
+					query: { limit: "10", offset: "0" },
+				});
+
+				const mockMutedUsers = {
+					users: [
+						{
+							did: mockTargetUser.did,
+							reason: "spam",
+							muted_at: new Date("2023-01-01"),
+							muted_by: mockUser.did,
+							last_synced_at: new Date("2023-01-01"),
+							sync_status: "synced" as const,
+							tags: ["offensive"],
+							record_key: "abc123",
+						},
+					],
+					total: 1,
+				};
+				jest.spyOn(mute, "getMutedUsers").mockResolvedValue(mockMutedUsers);
+
+				await listMutedUsersHandler(req, res);
+
+				expect(mute.getMutedUsers).toHaveBeenCalledWith({
+					limit: 10,
+					offset: 0,
+				});
+				expect(mockStatus).toHaveBeenCalledWith(200);
+				expect(mockJson).toHaveBeenCalledWith({
+					users: mockMutedUsers.users,
+					total: 1,
+					limit: 10,
+					offset: 0,
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
This PR adds the ability for the API to handle requests to ban users from TV as well as mute list members. This functionality currently exists specifically for Blacksky, but I can change it so that it's flexible for any feed if necessary.

## Code change structure

### Banning from TV
Directly calls the endpoint added to the `rsky-feedgen` service that adds a user to the banned_from_tv database. Also has support for unbanning a user and searching through the lists of banned users

### Muting

Adding functionality to mute / unmute users by adding them to the green list required:
1. OAuth for the admin account of the mute list (default blackskyweb.xyz): This reuses much of the same existing OAuth flow, with access and refresh tokens stored encrypted in the database. The OAuth flow is accessible at `admin/auth/signin` and will require somebody with credentials to `MUTE_LIST_ADMIN_DID` to sign-in for the mute features to work. Token refresh is handled automatically after that until the refresh token expires as well.
2. Local backup of muted list members for easy retrieval of mute status: The `muted_users` table is created, which is searched through when retrieving a user's mute status. This table is also updated when users are muted.
3. Syncing between the remote list and the local DB list: On server startup, there is a reconciliation process that is scheduled to run every `RECONCILIATION_INTERVAL_MS` ms (default 5 mins). This reconciliation process ensures that 1. if users are added to or removed from the list not through SAFESkies, their records are added to the database 2. users added to the database exist in the mute list. If adding a user to the mute list fails for whatever reason, the record of the mute list is marked `pending` and will be retried the next time the reconciliation process runs. If it fails on retry, it is marked failed. 

For deployment, environment variables `MUTE_LIST_ADMIN_DID` will need to be set `MUTE_LIST_URI`. On re-deployment, the admin will need to navigate to `/admin/auth/signin` and login with their MUTE_LIST_ADMIN_DID (@blackskyweb.xyz) credentials.